### PR TITLE
Improve project setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ bin/
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# generated source code
+**/xtend-gen/*

--- a/.project
+++ b/.project
@@ -14,4 +14,24 @@
 	<natures>
 		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1463585811953</id>
+			<name></name>
+			<type>10</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-com.opcoach.genmodeladdon*</arguments>
+			</matcher>
+		</filter>
+		<filter>
+			<id>1463585811971</id>
+			<name></name>
+			<type>10</type>
+			<matcher>
+				<id>org.eclipse.ui.ide.multiFilter</id>
+				<arguments>1.0-name-matches-false-false-build</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/genModelAddon.setup
+++ b/genModelAddon.setup
@@ -43,13 +43,15 @@
   <setupTask
       xsi:type="setup.p2:P2Task">
     <requirement
+        name="org.eclipse.m2e.feature.feature.group"/>
+  </setupTask>
+  <setupTask
+      xsi:type="setup.p2:P2Task">
+    <requirement
         name="org.eclipse.xtext.sdk.feature.group"
         versionRange="[2.9.2.v201603040440,2.9.2.v201603040440]"/>
     <requirement
         name="org.eclipse.emf.sdk.feature.group"/>
-    <requirement
-        name="org.eclipse.m2e.feature.feature.group"
-        versionRange="[1.6.2.20150902-0002,1.6.2.20150902-0002]"/>
     <repository
         url="http://download.eclipse.org/modeling/tmf/xtext/updates/composite/releases/"/>
     <description>Install the tools needed in the IDE to work with the source code for ${scope.project.label}</description>


### PR DESCRIPTION
* Add `xtend-gen` folder to the ignored files
* Hide the child folders from the root project `com.opcoach.genmodeladdon.parent` as [suggested by Ed Merks in this thread](https://www.eclipse.org/forums/index.php?t=msg&th=1073101&goto=1717878#msg_1717878)
* Move `org.eclipse.m2e.feature.feature.group` to an separated "P2Task". You cannot have multiple "repository" in one "P2Task" and the m2e feature is not in the xtext "update site". In the new "P2Task" there is no repository set. This way Oomph take the default one (mars or neon release train update site depending on the user choice)